### PR TITLE
build using debian instead of alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.13.2-alpine3.15 as builder
+FROM node:16.14.0-bullseye-slim as builder
 
 WORKDIR /app
 


### PR DESCRIPTION
There have been issues building the Docker image for arm64. We have _not_ had those same issues building Brigade's worker component (which is also Node-based) for arm64. The key difference seems to be we use Alpine here, but Debian for the worker.

This PR swaps us to using a Debian-based Docker image for the builds, in hopes this resolves the issue.