### PR TITLE
temporarily disable build of arm64-based images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ build:
 	docker buildx build \
 		-t $(DOCKER_IMAGE_NAME):$(IMMUTABLE_DOCKER_TAG) \
 		-t $(DOCKER_IMAGE_NAME):$(MUTABLE_DOCKER_TAG) \
-		--platform linux/amd64,linux/arm64 \
+		--platform linux/amd64 \
 		.
 
 ################################################################################
@@ -78,7 +78,7 @@ push:
 	docker buildx build \
 		-t $(DOCKER_IMAGE_NAME):$(IMMUTABLE_DOCKER_TAG) \
 		-t $(DOCKER_IMAGE_NAME):$(MUTABLE_DOCKER_TAG) \
-		--platform linux/amd64,linux/arm64 \
+		--platform linux/amd64 \
 		--push \
 		.
 


### PR DESCRIPTION
This PR is an alternative to #1, which failed to address the issue of arm64 builds failing.

I found this related issue: https://github.com/nodejs/docker-node/issues/1335