### PR TITLE
use prettier to enforce and correct coding style

### DIFF
--- a/.brigade/brigade.ts
+++ b/.brigade/brigade.ts
@@ -8,13 +8,18 @@ const nodeImg = "node:16.13.2-alpine3.15"
 
 // MakeTargetJob is just a job wrapper around one or more make targets.
 class MakeTargetJob extends Job {
-  constructor(targets: string[], img: string, event: Event, env?: {[key: string]: string}) {
+  constructor(
+    targets: string[],
+    img: string,
+    event: Event,
+    env?: { [key: string]: string }
+  ) {
     super(targets[0], img, event)
     this.primaryContainer.sourceMountPath = localPath
     this.primaryContainer.workingDirectory = localPath
     this.primaryContainer.environment = env || {}
     this.primaryContainer.environment["SKIP_DOCKER"] = "true"
-    this.primaryContainer.command = [ "make" ]
+    this.primaryContainer.command = ["make"]
     this.primaryContainer.arguments = targets
   }
 }
@@ -40,7 +45,7 @@ class MakeTargetJob extends Job {
 //
 // Tempting as it is to create a new builder using the Kubernetes driver (i.e.
 // `docker buildx create --driver kubernetes`), this comes with two problems:
-// 
+//
 // 1. It would require giving our jobs a lot of additional permissions that they
 //    don't otherwise need (creating deployments, for instance). This represents
 //    an attack vector I'd rather not open.
@@ -59,14 +64,14 @@ class MakeTargetJob extends Job {
 // If and when the capability exists to use `docker buildx` with existing
 // builders, we can streamline all of this pretty significantly.
 class BuildImageJob extends MakeTargetJob {
-  constructor(target: string, event: Event, env?: {[key: string]: string}) {
+  constructor(target: string, event: Event, env?: { [key: string]: string }) {
     env ||= {}
     env["DOCKER_ORG"] = event.project.secrets.dockerhubOrg
     env["DOCKER_USERNAME"] = event.project.secrets.dockerhubUsername
     env["DOCKER_PASSWORD"] = event.project.secrets.dockerhubPassword
     super([target], dockerClientImg, event, env)
     this.primaryContainer.environment.DOCKER_HOST = "localhost:2375"
-    this.primaryContainer.command = [ "sh" ]
+    this.primaryContainer.command = ["sh"]
     this.primaryContainer.arguments = [
       "-c",
       // The sleep is a grace period after which we assume the DinD sidecar is
@@ -76,7 +81,7 @@ class BuildImageJob extends MakeTargetJob {
 
     this.sidecarContainers.docker = new Container(dindImg)
     this.sidecarContainers.docker.privileged = true
-    this.sidecarContainers.docker.environment.DOCKER_TLS_CERTDIR=""
+    this.sidecarContainers.docker.environment.DOCKER_TLS_CERTDIR = ""
   }
 }
 
@@ -93,7 +98,7 @@ class PushImageJob extends BuildImageJob {
 
 // A map of all jobs. When a ci:job_requested event wants to re-run a single
 // job, this allows us to easily find that job by name.
-const jobs: {[key: string]: (event: Event) => Job } = {}
+const jobs: { [key: string]: (event: Event) => Job } = {}
 
 // Basic tests:
 
@@ -136,26 +141,23 @@ jobs[pushJobName] = pushJob
 const publishChartJobName = "publish-chart"
 const publishChartJob = (event: Event, version: string) => {
   return new MakeTargetJob([publishChartJobName], helmImg, event, {
-    "VERSION": version,
-    "HELM_REGISTRY": event.project.secrets.helmRegistry || "ghcr.io",
-    "HELM_ORG": event.project.secrets.helmOrg,
-    "HELM_USERNAME": event.project.secrets.helmUsername,
-    "HELM_PASSWORD": event.project.secrets.helmPassword
+    VERSION: version,
+    HELM_REGISTRY: event.project.secrets.helmRegistry || "ghcr.io",
+    HELM_ORG: event.project.secrets.helmOrg,
+    HELM_USERNAME: event.project.secrets.helmUsername,
+    HELM_PASSWORD: event.project.secrets.helmPassword
   })
 }
 
-events.on("brigade.sh/github", "ci:pipeline_requested", async event => {
+events.on("brigade.sh/github", "ci:pipeline_requested", async (event) => {
   await Job.sequence(
-    Job.concurrent(
-      styleCheckJob(event),
-      lintJob(event),
-    ),    
+    Job.concurrent(styleCheckJob(event), lintJob(event)),
     buildJob(event)
   ).run()
 })
 
 // This event indicates a specific job is to be re-run.
-events.on("brigade.sh/github", "ci:job_requested", async event => {
+events.on("brigade.sh/github", "ci:job_requested", async (event) => {
   const job = jobs[event.labels.job]
   if (job) {
     await job(event).run()
@@ -164,7 +166,7 @@ events.on("brigade.sh/github", "ci:job_requested", async event => {
   throw new Error(`No job found with name: ${event.labels.job}`)
 })
 
-events.on("brigade.sh/github", "cd:pipeline_requested", async event => {
+events.on("brigade.sh/github", "cd:pipeline_requested", async (event) => {
   const version = JSON.parse(event.payload).release.tag_name
   await Job.sequence(
     pushJob(event, version),

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,7 +5,8 @@
     },
     "extends": [
         "eslint:recommended",
-        "plugin:@typescript-eslint/recommended"
+        "plugin:@typescript-eslint/recommended",
+        "prettier"
     ],
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
@@ -17,10 +18,6 @@
     ],
     "rules": {
         "@typescript-eslint/ban-ts-comment": "off",
-        "indent": [
-            "error",
-            2
-        ],
         "linebreak-style": [
             "error",
             "unix"

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,34 +1,23 @@
 {
-    "env": {
-        "browser": true,
-        "es2021": true
-    },
-    "extends": [
-        "eslint:recommended",
-        "plugin:@typescript-eslint/recommended",
-        "prettier"
-    ],
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-        "ecmaVersion": 12,
-        "sourceType": "module"
-    },
-    "plugins": [
-        "@typescript-eslint"
-    ],
-    "rules": {
-        "@typescript-eslint/ban-ts-comment": "off",
-        "linebreak-style": [
-            "error",
-            "unix"
-        ],
-        "quotes": [
-            "error",
-            "double"
-        ],
-        "semi": [
-            "error",
-            "never"
-        ]
-    }
+  "env": {
+    "browser": true,
+    "es2021": true
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "prettier"
+  ],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": 12,
+    "sourceType": "module"
+  },
+  "plugins": ["@typescript-eslint"],
+  "rules": {
+    "@typescript-eslint/ban-ts-comment": "off",
+    "linebreak-style": ["error", "unix"],
+    "quotes": ["error", "double"],
+    "semi": ["error", "never"]
+  }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ yarn-error.log*
 
 .brigade/secrets.yaml
 .brigade/node_modules/
+
+.vscode/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+/build
+/node_modules
+
+*.md
+*.yaml

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+  "semi": false,
+  "trailingComma": "none"
+}

--- a/config-overrides.js
+++ b/config-overrides.js
@@ -1,13 +1,13 @@
 module.exports = {
-  webpack: function(config, env) {
+  webpack: function (config, env) {
     config.resolve.fallback = {
-      "events": require.resolve("events/"),
-      "http": false,
-      "https": false,
-      "process": false,
-      "url": false,
-      "util": false
+      events: require.resolve("events/"),
+      http: false,
+      https: false,
+      process: false,
+      url: false,
+      util: false
     }
-    return config;
+    return config
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "build": "react-app-rewired build",
     "test": "react-app-rewired test",
     "eject": "react-scripts eject",
+    "style:check": "prettier --check .",
+    "style:fix": "prettier --write .",
     "lint": "eslint src/"
   },
   "eslintConfig": {
@@ -63,6 +65,8 @@
     "@typescript-eslint/eslint-plugin": "^5.14.0",
     "@typescript-eslint/parser": "^5.14.0",
     "eslint": "^8.10.0",
+    "eslint-config-prettier": "^8.5.0",
+    "prettier": "2.5.1",
     "react-app-rewired": "^2.1.9"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -5,14 +5,17 @@
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
-    <meta name="description" content="Brigade Dashboard"/>
+    <meta name="description" content="Brigade Dashboard" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <link href="https://fonts.googleapis.com/css2?family=Work+Sans:wght@400;600&display=swap" rel="stylesheet"/>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Work+Sans:wght@400;600&display=swap"
+      rel="stylesheet"
+    />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/src/App.scss
+++ b/src/App.scss
@@ -6,8 +6,9 @@
 // }
 
 $colord: #277a9f;
-$text: #647B83;
-$work: "work_sansregular", "Work Sans", "Helvetica Neue", Helvetica, Arial, Geneva, sans-serif;
+$text: #647b83;
+$work: "work_sansregular", "Work Sans", "Helvetica Neue", Helvetica, Arial,
+  Geneva, sans-serif;
 
 body {
   font-family: $work !important;
@@ -18,7 +19,8 @@ a:not(.nav-link) {
   color: $colord !important;
 }
 
-.page-heading, .section-heading {
+.page-heading,
+.section-heading {
   color: $colord;
   margin-bottom: 20px;
   margin-top: 20px;
@@ -34,7 +36,9 @@ a:not(.nav-link) {
   margin-bottom: 20px;
   margin-top: 20px;
 
-  .card-header, .card-title, .card-subtitle {
+  .card-header,
+  .card-title,
+  .card-subtitle {
     color: $colord !important;
   }
 
@@ -44,14 +48,14 @@ a:not(.nav-link) {
   }
 }
 
-.nav-pills, .nav-tabs {
+.nav-pills,
+.nav-tabs {
   .nav-link {
     color: $colord !important;
     &:hover {
       cursor: pointer;
     }
   }
-  
 }
 
 .nav-pills .nav-link.active {
@@ -65,7 +69,8 @@ a:not(.nav-link) {
 }
 
 .table {
-  th, td {
+  th,
+  td {
     color: $text !important;
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,6 @@ interface AppState {
 }
 
 export default class App extends React.Component<unknown, AppState> {
-
   constructor(props: unknown) {
     super(props)
     this.state = {
@@ -31,11 +30,9 @@ export default class App extends React.Component<unknown, AppState> {
 
   handleLogin = async () => {
     const sessionsClient = getClient().authn().sessions()
-    const thirdPartyAuthDetails = await sessionsClient.createUserSession(
-      {
-        successURL: window.location.href
-      }
-    )
+    const thirdPartyAuthDetails = await sessionsClient.createUserSession({
+      successURL: window.location.href
+    })
     localStorage.setItem(consts.brigadeAPITokenKey, thirdPartyAuthDetails.token)
     window.location.href = thirdPartyAuthDetails.authURL
   }
@@ -56,7 +53,7 @@ export default class App extends React.Component<unknown, AppState> {
             <Container>
               <LinkContainer to="/">
                 <Navbar.Brand>
-                  <img src={logoDark} height="40"/>
+                  <img src={logoDark} height="40" />
                 </Navbar.Brand>
               </LinkContainer>
               <Navbar.Toggle aria-controls="basic-navbar-nav" />
@@ -78,34 +75,37 @@ export default class App extends React.Component<unknown, AppState> {
                     <Nav.Link>System Permissions</Nav.Link>
                   </LinkContainer>
                 </Nav>
-                <LoginControl loggedIn={loggedIn} onLogin={this.handleLogin} onLogout={this.handleLogout}/>
+                <LoginControl
+                  loggedIn={loggedIn}
+                  onLogin={this.handleLogin}
+                  onLogout={this.handleLogout}
+                />
               </Navbar.Collapse>
             </Container>
           </Navbar>
         </header>
         <main>
           <Container>
-            {
-              loggedIn ? (
-                <Outlet/>
-              ) : (
-                <div>
-                  <Alert variant="primary">Log in to see this content.</Alert>
-                  <Home/>
-                </div>
-              )
-            }
+            {loggedIn ? (
+              <Outlet />
+            ) : (
+              <div>
+                <Alert variant="primary">Log in to see this content.</Alert>
+                <Home />
+              </div>
+            )}
           </Container>
         </main>
         <footer>
           <Navbar bg="dark" variant="dark" expand="lg" fixed="bottom">
             <Container>
-              <span className="text-muted">&copy; 2022 The Brigade Authors</span>
+              <span className="text-muted">
+                &copy; 2022 The Brigade Authors
+              </span>
             </Container>
           </Navbar>
         </footer>
       </Fragment>
     )
   }
-
 }

--- a/src/Event.tsx
+++ b/src/Event.tsx
@@ -33,7 +33,6 @@ interface EventState {
 
 // TODO: Need to make this component auto-refresh
 class Event extends React.Component<EventProps, EventState> {
-
   constructor(props: EventProps) {
     super(props)
     this.state = {}
@@ -48,35 +47,38 @@ class Event extends React.Component<EventProps, EventState> {
   render(): React.ReactElement {
     const event = this.state.event
     if (!event) {
-      return <Spinner/>
+      return <Spinner />
     }
     return (
       <div>
         <h1 className="page-heading">{event?.metadata?.id}</h1>
         <Tabs defaultActiveKey="summary" className="mb-3" mountOnEnter={true}>
           <Tab eventKey="summary" title="Summary">
-            <EventSummary event={event}/>
+            <EventSummary event={event} />
           </Tab>
           <Tab eventKey="yaml" title="YAML">
-            <YAMLViewer object={event}/>
+            <YAMLViewer object={event} />
           </Tab>
-          { event.git ? <Tab eventKey="git-initializer-logs" title="Git Initializer Logs"><LogStreamer event={event} containerName="vcs" logKey="vcs"/></Tab> : null }
+          {event.git ? (
+            <Tab eventKey="git-initializer-logs" title="Git Initializer Logs">
+              <LogStreamer event={event} containerName="vcs" logKey="vcs" />
+            </Tab>
+          ) : null}
           <Tab eventKey="worker-logs" title="Worker Logs">
-            <LogStreamer event={event} logKey={event?.metadata?.id || ""}/>
+            <LogStreamer event={event} logKey={event?.metadata?.id || ""} />
           </Tab>
           <Tab eventKey="jobs" title="Jobs">
-            <JobTabs event={event}/>
+            <JobTabs event={event} />
           </Tab>
         </Tabs>
       </div>
     )
   }
-
 }
 
 export default function RoutedEvent(): React.ReactElement {
   const pathParams = useParams()
-  return <Event id={pathParams.id || ""}/>
+  return <Event id={pathParams.id || ""} />
 }
 
 interface EventSummaryProps {
@@ -84,38 +86,37 @@ interface EventSummaryProps {
 }
 
 class EventSummary extends React.Component<EventSummaryProps> {
-
   render(): React.ReactElement {
     const event = this.props.event
     let phaseColor = "light"
-    switch(event.worker?.status.phase) {
-    case core.WorkerPhase.Aborted:
-      phaseColor = "danger"
-      break
-    case core.WorkerPhase.Canceled:
-      phaseColor = "danger"
-      break
-    case core.WorkerPhase.Failed:
-      phaseColor = "danger"
-      break
-    case core.WorkerPhase.Pending:
-      phaseColor = "warning"
-      break
-    case core.WorkerPhase.Running:
-      phaseColor = "warning"
-      break
-    case core.WorkerPhase.SchedulingFailed:
-      phaseColor = "danger"
-      break
-    case core.WorkerPhase.Starting:
-      phaseColor = "goldenrod"
-      break
-    case core.WorkerPhase.Succeeded:
-      phaseColor = "success"
-      break
-    case core.WorkerPhase.TimedOut:
-      phaseColor = "danger"
-      break
+    switch (event.worker?.status.phase) {
+      case core.WorkerPhase.Aborted:
+        phaseColor = "danger"
+        break
+      case core.WorkerPhase.Canceled:
+        phaseColor = "danger"
+        break
+      case core.WorkerPhase.Failed:
+        phaseColor = "danger"
+        break
+      case core.WorkerPhase.Pending:
+        phaseColor = "warning"
+        break
+      case core.WorkerPhase.Running:
+        phaseColor = "warning"
+        break
+      case core.WorkerPhase.SchedulingFailed:
+        phaseColor = "danger"
+        break
+      case core.WorkerPhase.Starting:
+        phaseColor = "goldenrod"
+        break
+      case core.WorkerPhase.Succeeded:
+        phaseColor = "success"
+        break
+      case core.WorkerPhase.TimedOut:
+        phaseColor = "danger"
+        break
     }
     return (
       <Container>
@@ -129,7 +130,9 @@ class EventSummary extends React.Component<EventSummaryProps> {
                     <tr>
                       <th>Project</th>
                       <td>
-                        <Link to={"/projects/" + event.projectID}>{event.projectID}</Link>
+                        <Link to={"/projects/" + event.projectID}>
+                          {event.projectID}
+                        </Link>
                       </td>
                     </tr>
                     <tr>
@@ -140,94 +143,84 @@ class EventSummary extends React.Component<EventSummaryProps> {
                       <th>Type</th>
                       <td>{event.type}</td>
                     </tr>
-                    {
-                      event.qualifiers ? (
-                        <tr>
-                          <th>Qualifiers</th>
-                          <td>
-                            <Table borderless hover>
-                              <tbody>
-                                { 
-                                  Object.entries(event.qualifiers).map((entry: string[]) => (
-                                    <tr>
-                                      <th>{entry[0]}</th>
-                                      <td>{entry[1]}</td>
-                                    </tr>
-                                  ))
-                                }
-                              </tbody>
-                            </Table>
-                          </td>
-                        </tr>
-                      ) : null
-                    }
-                    {
-                      event.labels ? (
-                        <tr>
-                          <th>Labels</th>
-                          <td>
-                            <Table borderless hover>
-                              <tbody>
-                                { 
-                                  Object.entries(event.labels).map((entry: string[]) => (
-                                    <tr>
-                                      <th>{entry[0]}</th>
-                                      <td>{entry[1]}</td>
-                                    </tr>
-                                  ))
-                                }
-                              </tbody>
-                            </Table>
-                          </td>
-                        </tr>
-                      ) : null
-                    }
-                    { 
-                      event.git ? (
-                        <tr>
-                          <th>Git</th>
-                          <td>
-                            <Table borderless hover>
-                              <tbody>
-                                { 
-                                  event.git.cloneURL ? (
-                                    <tr>
-                                      <th>Clone URL</th>
-                                      <td>
-                                        {event.git.cloneURL}
-                                        <Link to={event.git.cloneURL}>
-                                          {event.git.cloneURL}
-                                        </Link>
-                                      </td>
-                                    </tr>
-                                  ) : null
-                                }
-                                {
-                                  event.git.ref ? (
-                                    <tr>
-                                      <th>Ref</th>
-                                      <td>{event.git.ref}</td>
-                                    </tr>
-                                  ) : null
-                                }
-                                {
-                                  event.git.commit ? (
-                                    <tr>
-                                      <th>Commit</th>
-                                      <td>{event.git.commit}</td>
-                                    </tr>
-                                  ) : null
-                                }
-                              </tbody>
-                            </Table>
-                          </td>
-                        </tr>
-                      ) : null
-                    }
+                    {event.qualifiers ? (
+                      <tr>
+                        <th>Qualifiers</th>
+                        <td>
+                          <Table borderless hover>
+                            <tbody>
+                              {Object.entries(event.qualifiers).map(
+                                (entry: string[]) => (
+                                  <tr>
+                                    <th>{entry[0]}</th>
+                                    <td>{entry[1]}</td>
+                                  </tr>
+                                )
+                              )}
+                            </tbody>
+                          </Table>
+                        </td>
+                      </tr>
+                    ) : null}
+                    {event.labels ? (
+                      <tr>
+                        <th>Labels</th>
+                        <td>
+                          <Table borderless hover>
+                            <tbody>
+                              {Object.entries(event.labels).map(
+                                (entry: string[]) => (
+                                  <tr>
+                                    <th>{entry[0]}</th>
+                                    <td>{entry[1]}</td>
+                                  </tr>
+                                )
+                              )}
+                            </tbody>
+                          </Table>
+                        </td>
+                      </tr>
+                    ) : null}
+                    {event.git ? (
+                      <tr>
+                        <th>Git</th>
+                        <td>
+                          <Table borderless hover>
+                            <tbody>
+                              {event.git.cloneURL ? (
+                                <tr>
+                                  <th>Clone URL</th>
+                                  <td>
+                                    {event.git.cloneURL}
+                                    <Link to={event.git.cloneURL}>
+                                      {event.git.cloneURL}
+                                    </Link>
+                                  </td>
+                                </tr>
+                              ) : null}
+                              {event.git.ref ? (
+                                <tr>
+                                  <th>Ref</th>
+                                  <td>{event.git.ref}</td>
+                                </tr>
+                              ) : null}
+                              {event.git.commit ? (
+                                <tr>
+                                  <th>Commit</th>
+                                  <td>{event.git.commit}</td>
+                                </tr>
+                              ) : null}
+                            </tbody>
+                          </Table>
+                        </td>
+                      </tr>
+                    ) : null}
                     <tr>
                       <th>Created</th>
                       <td>
-                        {moment(event.metadata?.created).utc().format("YYYY-MM-DD HH:mm:ss Z")}
+                        {moment(event.metadata?.created)
+                          .utc()
+                          .format("YYYY-MM-DD HH:mm:ss Z")}
                       </td>
                     </tr>
                   </tbody>
@@ -238,47 +231,52 @@ class EventSummary extends React.Component<EventSummaryProps> {
           <Col>
             <Card border={phaseColor} bg="light">
               <Card.Header>
-                <WorkerPhaseIcon phase={event.worker?.status.phase}/>
-                &nbsp;&nbsp;
-                Worker
+                <WorkerPhaseIcon phase={event.worker?.status.phase} />
+                &nbsp;&nbsp; Worker
               </Card.Header>
               <Card.Body>
                 <Table borderless hover>
-                  <tbody>  
+                  <tbody>
                     <tr>
                       <th>Image</th>
-                      <td>{event.worker?.spec.container?.image || "DEFAULT"}</td>
+                      <td>
+                        {event.worker?.spec.container?.image || "DEFAULT"}
+                      </td>
                     </tr>
-                    {
-                      event.worker?.status.started ? (
-                        <tr>
-                          <th>Started</th>
-                          <td>
-                            {moment(event.worker?.status.started).utc().format("YYYY-MM-DD HH:mm:ss Z")}
-                          </td>
-                        </tr>
-                      ) : null
-                    }
-                    {
-                      event.worker?.status.ended ? (
-                        <tr>
-                          <th>Ended</th>
-                          <td>
-                            {moment(event.worker?.status.ended).utc().format("YYYY-MM-DD HH:mm:ss Z")}
-                          </td>
-                        </tr>
-                      ) : null
-                    }
-                    {
-                      event.worker?.status.ended ? (
-                        <tr>
-                          <th>Duration</th>
-                          <td>
-                            {moment.duration(moment(event.worker?.status.ended).diff(moment(event.worker?.status.started))).humanize()}
-                          </td>
-                        </tr>
-                      ) : null
-                    }
+                    {event.worker?.status.started ? (
+                      <tr>
+                        <th>Started</th>
+                        <td>
+                          {moment(event.worker?.status.started)
+                            .utc()
+                            .format("YYYY-MM-DD HH:mm:ss Z")}
+                        </td>
+                      </tr>
+                    ) : null}
+                    {event.worker?.status.ended ? (
+                      <tr>
+                        <th>Ended</th>
+                        <td>
+                          {moment(event.worker?.status.ended)
+                            .utc()
+                            .format("YYYY-MM-DD HH:mm:ss Z")}
+                        </td>
+                      </tr>
+                    ) : null}
+                    {event.worker?.status.ended ? (
+                      <tr>
+                        <th>Duration</th>
+                        <td>
+                          {moment
+                            .duration(
+                              moment(event.worker?.status.ended).diff(
+                                moment(event.worker?.status.started)
+                              )
+                            )
+                            .humanize()}
+                        </td>
+                      </tr>
+                    ) : null}
                   </tbody>
                 </Table>
               </Card.Body>
@@ -288,7 +286,6 @@ class EventSummary extends React.Component<EventSummaryProps> {
       </Container>
     )
   }
-
 }
 
 interface JobTabsProps {
@@ -296,12 +293,15 @@ interface JobTabsProps {
 }
 
 class JobTabs extends React.Component<JobTabsProps> {
-
   render(): React.ReactElement {
     const event = this.props.event
     const jobs = event.worker?.jobs
     if (!jobs || jobs.length === 0) {
-      return <Alert variant="primary">There are no jobs associated with this event.</Alert>
+      return (
+        <Alert variant="primary">
+          There are no jobs associated with this event.
+        </Alert>
+      )
     }
     const defaultJobName = jobs[0].name
     return (
@@ -309,31 +309,29 @@ class JobTabs extends React.Component<JobTabsProps> {
         <Row>
           <Col sm={3}>
             <Nav variant="pills" className="flex-column">
-              {
-                jobs.map((job: core.Job) => (
-                  <Nav.Item>
-                    <Nav.Link eventKey={job.name}><JobPhaseIcon phase={job.status?.phase}/>&nbsp;&nbsp;{job.name}</Nav.Link>
-                  </Nav.Item>
-                ))
-              }
+              {jobs.map((job: core.Job) => (
+                <Nav.Item>
+                  <Nav.Link eventKey={job.name}>
+                    <JobPhaseIcon phase={job.status?.phase} />
+                    &nbsp;&nbsp;{job.name}
+                  </Nav.Link>
+                </Nav.Item>
+              ))}
             </Nav>
           </Col>
           <Col sm={9}>
             <Tab.Content>
-              {
-                jobs.map((job: core.Job) => (
-                  <Tab.Pane eventKey={job.name} mountOnEnter>
-                    <JobTabPane key={job.name} event={event} job={job}/>
-                  </Tab.Pane>
-                ))
-              }
+              {jobs.map((job: core.Job) => (
+                <Tab.Pane eventKey={job.name} mountOnEnter>
+                  <JobTabPane key={job.name} event={event} job={job} />
+                </Tab.Pane>
+              ))}
             </Tab.Content>
           </Col>
         </Row>
       </Tab.Container>
     )
   }
-
 }
 
 interface JobTabPaneProps {
@@ -342,49 +340,61 @@ interface JobTabPaneProps {
 }
 
 class JobTabPane extends React.Component<JobTabPaneProps> {
-
   render(): React.ReactElement {
     const event = this.props.event
     const job = this.props.job
     let usesSource = job.spec.primaryContainer.sourceMountPath ? true : false
     if (!usesSource && job.spec.sidecarContainers) {
-      Object.keys(job.spec.sidecarContainers).forEach((containerName: string) => {
-        if (job.spec.sidecarContainers && job.spec.sidecarContainers[containerName] && job.spec.sidecarContainers[containerName].sourceMountPath) {
-          usesSource = true
+      Object.keys(job.spec.sidecarContainers).forEach(
+        (containerName: string) => {
+          if (
+            job.spec.sidecarContainers &&
+            job.spec.sidecarContainers[containerName] &&
+            job.spec.sidecarContainers[containerName].sourceMountPath
+          ) {
+            usesSource = true
+          }
         }
-      })
+      )
     }
     return (
       <div>
         <Tabs defaultActiveKey="summary" className="mb-3" mountOnEnter={true}>
           <Tab eventKey="summary" title="Summary">
-            <JobSummary job={job}/>
+            <JobSummary job={job} />
           </Tab>
           <Tab eventKey="yaml" title="YAML">
-            <YAMLViewer object={job}/>
+            <YAMLViewer object={job} />
           </Tab>
-          { 
-            usesSource ? (
-              <Tab eventKey="git-initializer-logs" title="Git Initializer Logs">
-                <LogStreamer event={event} jobName={job.name} containerName="vcs" logKey="vcs"/>
-              </Tab>
-            ) : null
-          }
+          {usesSource ? (
+            <Tab eventKey="git-initializer-logs" title="Git Initializer Logs">
+              <LogStreamer
+                event={event}
+                jobName={job.name}
+                containerName="vcs"
+                logKey="vcs"
+              />
+            </Tab>
+          ) : null}
           <Tab eventKey={job.name} title={`${job.name} Logs`}>
-            <LogStreamer event={event} jobName={job.name} logKey={job.name}/>
+            <LogStreamer event={event} jobName={job.name} logKey={job.name} />
           </Tab>
-          {
-            Object.keys(job.spec.sidecarContainers || {}).map((containerName: string) => (
+          {Object.keys(job.spec.sidecarContainers || {}).map(
+            (containerName: string) => (
               <Tab eventKey={containerName} title={`${containerName} Logs`}>
-                <LogStreamer event={event} jobName={job.name} containerName={containerName} logKey={`${job.name}-${containerName}`}/>
+                <LogStreamer
+                  event={event}
+                  jobName={job.name}
+                  containerName={containerName}
+                  logKey={`${job.name}-${containerName}`}
+                />
               </Tab>
-            ))
-          }
+            )
+          )}
         </Tabs>
       </div>
     )
   }
-
 }
 
 interface JobSummaryProps {
@@ -392,44 +402,43 @@ interface JobSummaryProps {
 }
 
 class JobSummary extends React.Component<JobSummaryProps> {
-
   render(): React.ReactElement {
     const job = this.props.job
     let phaseColor = "light"
-    switch(job.status?.phase) {
-    case core.JobPhase.Aborted:
-      phaseColor = "danger"
-      break
-    case core.JobPhase.Canceled:
-      phaseColor = "danger"
-      break
-    case core.JobPhase.Failed:
-      phaseColor = "danger"
-      break
-    case core.JobPhase.Pending:
-      phaseColor = "warning"
-      break
-    case core.JobPhase.Running:
-      phaseColor = "warning"
-      break
-    case core.JobPhase.SchedulingFailed:
-      phaseColor = "danger"
-      break
-    case core.JobPhase.Starting:
-      phaseColor = "goldenrod"
-      break
-    case core.JobPhase.Succeeded:
-      phaseColor = "success"
-      break
-    case core.JobPhase.TimedOut:
-      phaseColor = "danger"
-      break
+    switch (job.status?.phase) {
+      case core.JobPhase.Aborted:
+        phaseColor = "danger"
+        break
+      case core.JobPhase.Canceled:
+        phaseColor = "danger"
+        break
+      case core.JobPhase.Failed:
+        phaseColor = "danger"
+        break
+      case core.JobPhase.Pending:
+        phaseColor = "warning"
+        break
+      case core.JobPhase.Running:
+        phaseColor = "warning"
+        break
+      case core.JobPhase.SchedulingFailed:
+        phaseColor = "danger"
+        break
+      case core.JobPhase.Starting:
+        phaseColor = "goldenrod"
+        break
+      case core.JobPhase.Succeeded:
+        phaseColor = "success"
+        break
+      case core.JobPhase.TimedOut:
+        phaseColor = "danger"
+        break
     }
     return (
       <div>
         <Card border={phaseColor} bg="light">
           <Card.Header>
-            <JobPhaseIcon phase={job.status?.phase}/>
+            <JobPhaseIcon phase={job.status?.phase} />
             &nbsp;&nbsp;
             {job.name}
           </Card.Header>
@@ -440,36 +449,40 @@ class JobSummary extends React.Component<JobSummaryProps> {
                   <th>Created</th>
                   <td>Placeholder</td>
                 </tr>
-                {
-                  job.status?.started ? (
-                    <tr>
-                      <th>Started</th>
-                      <td>
-                        {moment(job.status?.started).utc().format("YYYY-MM-DD HH:mm:ss Z")}
-                      </td>
-                    </tr>
-                  ) : null
-                }
-                {
-                  job.status?.ended ? (
-                    <tr>
-                      <th>Ended</th>
-                      <td>
-                        {moment(job.status?.started).utc().format("YYYY-MM-DD HH:mm:ss Z")}
-                      </td>
-                    </tr>
-                  ) : null
-                }
-                {
-                  job.status?.ended ? (
-                    <tr>
-                      <th>Duration</th>
-                      <td>
-                        {moment.duration(moment(job.status?.ended).diff(moment(job.status?.started))).humanize()}
-                      </td>
-                    </tr>
-                  ) : null
-                }
+                {job.status?.started ? (
+                  <tr>
+                    <th>Started</th>
+                    <td>
+                      {moment(job.status?.started)
+                        .utc()
+                        .format("YYYY-MM-DD HH:mm:ss Z")}
+                    </td>
+                  </tr>
+                ) : null}
+                {job.status?.ended ? (
+                  <tr>
+                    <th>Ended</th>
+                    <td>
+                      {moment(job.status?.started)
+                        .utc()
+                        .format("YYYY-MM-DD HH:mm:ss Z")}
+                    </td>
+                  </tr>
+                ) : null}
+                {job.status?.ended ? (
+                  <tr>
+                    <th>Duration</th>
+                    <td>
+                      {moment
+                        .duration(
+                          moment(job.status?.ended).diff(
+                            moment(job.status?.started)
+                          )
+                        )
+                        .humanize()}
+                    </td>
+                  </tr>
+                ) : null}
               </tbody>
             </Table>
           </Card.Body>
@@ -487,18 +500,17 @@ class JobSummary extends React.Component<JobSummaryProps> {
               <td>{job.name} (primary container)</td>
               <td>{job.spec.primaryContainer.image}</td>
             </tr>
-            {
-              Object.entries(job.spec.sidecarContainers || {}).map((entry: unknown[]) => (
+            {Object.entries(job.spec.sidecarContainers || {}).map(
+              (entry: unknown[]) => (
                 <tr>
                   <td>{entry[0] as string}</td>
                   <td>{(entry[1] as core.ContainerSpec).image}</td>
                 </tr>
-              ))
-            }
-          </tbody>         
+              )
+            )}
+          </tbody>
         </Table>
       </div>
     )
   }
-
 }

--- a/src/EventList.tsx
+++ b/src/EventList.tsx
@@ -20,16 +20,24 @@ interface EventListItemProps {
 }
 
 class EventListItem extends React.Component<EventListItemProps> {
-
   render(): React.ReactElement {
     const event = this.props.event
     return (
       <tr>
         <td>
-          <WorkerPhaseIcon phase={event.worker?.status.phase}/>&nbsp;&nbsp;
-          <Link to={"/events/" + event.metadata?.id}>{this.props.event.metadata?.id}</Link>
+          <WorkerPhaseIcon phase={event.worker?.status.phase} />
+          &nbsp;&nbsp;
+          <Link to={"/events/" + event.metadata?.id}>
+            {this.props.event.metadata?.id}
+          </Link>
         </td>
-        { this.props.suppressProjectColumn ? null : <td><Link to={"/projects/" + event.projectID}>{this.props.event.projectID}</Link></td> }
+        {this.props.suppressProjectColumn ? null : (
+          <td>
+            <Link to={"/projects/" + event.projectID}>
+              {this.props.event.projectID}
+            </Link>
+          </td>
+        )}
         <td>{this.props.event.source}</td>
         <td>{this.props.event.type}</td>
         <td>{moment(this.props.event.metadata?.created).fromNow(true)}</td>
@@ -43,7 +51,10 @@ interface EventListProps {
 }
 
 export default withPagingControl(
-  (props: EventListProps, continueVal: string): Promise<meta.List<core.Event>> => {
+  (
+    props: EventListProps,
+    continueVal: string
+  ): Promise<meta.List<core.Event>> => {
     return getClient().core().events().list(props.selector, {
       continue: continueVal,
       limit: eventListPageSize
@@ -56,18 +67,20 @@ export default withPagingControl(
         <thead>
           <tr>
             <th>ID</th>
-            { suppressProjectColumn ? null : <th>Project</th> }
+            {suppressProjectColumn ? null : <th>Project</th>}
             <th>Source</th>
             <th>Type</th>
             <th>Age</th>
           </tr>
         </thead>
         <tbody>
-          {
-            events.map((event: core.Event) => (
-              <EventListItem key={event.metadata?.id} event={event} suppressProjectColumn={suppressProjectColumn}/>
-            ))
-          }
+          {events.map((event: core.Event) => (
+            <EventListItem
+              key={event.metadata?.id}
+              event={event}
+              suppressProjectColumn={suppressProjectColumn}
+            />
+          ))}
         </tbody>
       </Table>
     )

--- a/src/Events.tsx
+++ b/src/Events.tsx
@@ -3,14 +3,12 @@ import React from "react"
 import EventList from "./EventList"
 
 export default class Events extends React.Component {
-
   render(): React.ReactElement {
     return (
       <div>
         <h1 className="page-heading">All Events</h1>
-        <EventList/>
+        <EventList />
       </div>
     )
   }
-
 }

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -13,26 +13,24 @@ import logo from "./images/logo.png"
 import styles from "./Home.module.scss"
 
 export default class Home extends React.Component {
-
   render(): React.ReactElement {
     return (
       <Container>
         <Row>
           <Col className={styles.splash}>
-            <Image src={logo} fluid/>
+            <Image src={logo} fluid />
           </Col>
         </Row>
         <Row>
           <Col>
-            <BlogCard/>
+            <BlogCard />
           </Col>
           <Col>
-            <ResourcesCard/>
-            <ContributeCard/>
+            <ResourcesCard />
+            <ContributeCard />
           </Col>
         </Row>
       </Container>
     )
   }
-
 }

--- a/src/JobPhaseIcon.tsx
+++ b/src/JobPhaseIcon.tsx
@@ -1,4 +1,10 @@
-import { faCheck, faClock, faPlay, faQuestion, faTimes } from "@fortawesome/free-solid-svg-icons"
+import {
+  faCheck,
+  faClock,
+  faPlay,
+  faQuestion,
+  faTimes
+} from "@fortawesome/free-solid-svg-icons"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 
 import React from "react"
@@ -10,49 +16,47 @@ interface JobPhaseIconProps {
 }
 
 export default class JobPhaseIcon extends React.Component<JobPhaseIconProps> {
-
   render(): React.ReactElement {
     let icon = faQuestion
     let color = "dimgray"
-    switch(this.props.phase) {
-    case core.JobPhase.Aborted:
-      icon = faTimes
-      color = "firebrick"
-      break
-    case core.JobPhase.Canceled:
-      icon = faTimes
-      color = "firebrick"
-      break
-    case core.JobPhase.Failed:
-      icon = faTimes
-      color = "firebrick"
-      break
-    case core.JobPhase.Pending:
-      icon = faClock
-      color = "goldenrod"
-      break
-    case core.JobPhase.Running:
-      icon = faPlay
-      color = "goldenrod"
-      break
-    case core.JobPhase.SchedulingFailed:
-      icon = faTimes
-      color = "firebrick"
-      break
-    case core.JobPhase.Starting:
-      icon = faPlay
-      color = "goldenrod"
-      break
-    case core.JobPhase.Succeeded:
-      icon = faCheck
-      color = "green"
-      break
-    case core.JobPhase.TimedOut:
-      icon = faTimes
-      color = "firebrick"
-      break
+    switch (this.props.phase) {
+      case core.JobPhase.Aborted:
+        icon = faTimes
+        color = "firebrick"
+        break
+      case core.JobPhase.Canceled:
+        icon = faTimes
+        color = "firebrick"
+        break
+      case core.JobPhase.Failed:
+        icon = faTimes
+        color = "firebrick"
+        break
+      case core.JobPhase.Pending:
+        icon = faClock
+        color = "goldenrod"
+        break
+      case core.JobPhase.Running:
+        icon = faPlay
+        color = "goldenrod"
+        break
+      case core.JobPhase.SchedulingFailed:
+        icon = faTimes
+        color = "firebrick"
+        break
+      case core.JobPhase.Starting:
+        icon = faPlay
+        color = "goldenrod"
+        break
+      case core.JobPhase.Succeeded:
+        icon = faCheck
+        color = "green"
+        break
+      case core.JobPhase.TimedOut:
+        icon = faTimes
+        color = "firebrick"
+        break
     }
-    return <FontAwesomeIcon icon={icon} color={color}/>
+    return <FontAwesomeIcon icon={icon} color={color} />
   }
-
 }

--- a/src/LoginControl.tsx
+++ b/src/LoginControl.tsx
@@ -12,20 +12,22 @@ interface LoginControlState {
   loggedIn: boolean
 }
 
-export default class LoginControl extends React.Component<LoginControlProps, LoginControlState> {
-
+export default class LoginControl extends React.Component<
+  LoginControlProps,
+  LoginControlState
+> {
   constructor(props: LoginControlProps) {
     super(props)
-    this.state = {loggedIn: props.loggedIn}
+    this.state = { loggedIn: props.loggedIn }
   }
 
   handleLogin = () => {
-    this.setState({loggedIn: true})
+    this.setState({ loggedIn: true })
     this.props.onLogin()
   }
 
   handleLogout = () => {
-    this.setState({loggedIn: false})
+    this.setState({ loggedIn: false })
     this.props.onLogout()
   }
 
@@ -33,11 +35,18 @@ export default class LoginControl extends React.Component<LoginControlProps, Log
     const loggedIn = this.state.loggedIn
     let button
     if (!loggedIn) {
-      button = <Button variant="outline-light" onClick={this.handleLogin}>Login</Button>
+      button = (
+        <Button variant="outline-light" onClick={this.handleLogin}>
+          Login
+        </Button>
+      )
     } else {
-      button = <Button variant="outline-light" onClick={this.handleLogout}>Logout</Button>
+      button = (
+        <Button variant="outline-light" onClick={this.handleLogout}>
+          Logout
+        </Button>
+      )
     }
     return <div>{button}</div>
   }
-
 }

--- a/src/PrincipalIcon.tsx
+++ b/src/PrincipalIcon.tsx
@@ -14,22 +14,20 @@ interface PrincipalIconProps {
 }
 
 export default class PrincipalIcon extends React.Component<PrincipalIconProps> {
-
   render(): React.ReactElement {
     if (this.props.locked === null) {
-      return <Spinner animation="border" size="sm"/>
+      return <Spinner animation="border" size="sm" />
     }
     let icon = faQuestion
     const color = this.props.locked ? "firebrick" : "green"
-    switch(this.props.principalType) {
-    case authz.PrincipalTypeServiceAccount:
-      icon = faServer
-      break
-    case authz.PrincipalTypeUser:
-      icon = faUser
-      break
+    switch (this.props.principalType) {
+      case authz.PrincipalTypeServiceAccount:
+        icon = faServer
+        break
+      case authz.PrincipalTypeUser:
+        icon = faUser
+        break
     }
-    return <FontAwesomeIcon icon={icon} color={color}/>
+    return <FontAwesomeIcon icon={icon} color={color} />
   }
-
 }

--- a/src/Project.tsx
+++ b/src/Project.tsx
@@ -28,7 +28,6 @@ interface ProjectState {
 
 // TODO: Need to make this component auto-refresh
 class Project extends React.Component<ProjectProps, ProjectState> {
-
   constructor(props: ProjectProps) {
     super(props)
     this.state = {}
@@ -43,36 +42,35 @@ class Project extends React.Component<ProjectProps, ProjectState> {
   render(): React.ReactElement {
     const project = this.state.project
     if (!project) {
-      return <Spinner/>
+      return <Spinner />
     }
     return (
       <div>
         <h1 className="page-heading">{project?.metadata.id}</h1>
         <Tabs defaultActiveKey="summary" className="mb-3" mountOnEnter={true}>
           <Tab eventKey="summary" title="Summary">
-            <ProjectSummary project={project}/>
+            <ProjectSummary project={project} />
             <h2 className="section-heading">Events</h2>
-            <EventList selector={{projectID: project.metadata.id}}/>
+            <EventList selector={{ projectID: project.metadata.id }} />
           </Tab>
           <Tab eventKey="yaml" title="YAML">
-            <YAMLViewer object={project}/>
+            <YAMLViewer object={project} />
           </Tab>
           <Tab eventKey="secrets" title="Secrets">
-            <SecretsList projectID={project.metadata.id}/>
+            <SecretsList projectID={project.metadata.id} />
           </Tab>
           <Tab eventKey="permissions" title="Permissions">
-            <ProjectPermissionsList projectID={project.metadata.id}/>
+            <ProjectPermissionsList projectID={project.metadata.id} />
           </Tab>
         </Tabs>
       </div>
     )
   }
-
 }
 
 export default function RoutedProject(): React.ReactElement {
   const pathParams = useParams()
-  return <Project id={pathParams.id || ""}/>
+  return <Project id={pathParams.id || ""} />
 }
 
 interface ProjectSummaryProps {
@@ -80,7 +78,6 @@ interface ProjectSummaryProps {
 }
 
 class ProjectSummary extends React.Component<ProjectSummaryProps> {
-
   render(): React.ReactElement {
     const project = this.props.project
     return (
@@ -95,70 +92,63 @@ class ProjectSummary extends React.Component<ProjectSummaryProps> {
               </tr>
               <tr>
                 <th>Created</th>
-                <td>{moment(project.metadata.created).utc().format("YYYY-MM-DD HH:mm:ss Z")}</td>
+                <td>
+                  {moment(project.metadata.created)
+                    .utc()
+                    .format("YYYY-MM-DD HH:mm:ss Z")}
+                </td>
               </tr>
-              {
-                project.spec.workerTemplate.container?.image ? (
-                  <tr>
-                    <th>Image</th>
-                    <td>{project.spec.workerTemplate.container?.image}</td>
-                  </tr>
-                ) : null
-              }
-              { 
-                project.spec.workerTemplate.git ? (
-                  <tr>
-                    <th>Git</th>
-                    <td>
-                      <Table borderless hover>
-                        <tbody>
-                          { 
-                            project.spec.workerTemplate.git.cloneURL ? (
-                              <tr>
-                                <th>Clone URL</th>
-                                <td>
-                                  <Link to={project.spec.workerTemplate.git.cloneURL}>
-                                    {project.spec.workerTemplate.git.cloneURL}
-                                  </Link>
-                                </td>
-                              </tr>
-                            ) : null
-                          }
-                          {
-                            project.spec.workerTemplate.git.ref ? (
-                              <tr>
-                                <th>Ref</th>
-                                <td>{project.spec.workerTemplate.git.ref}</td>
-                              </tr>
-                            ) : null
-                          }
-                          {
-                            project.spec.workerTemplate.git.commit ? (
-                              <tr>
-                                <th>Commit</th>
-                                <td>{project.spec.workerTemplate.git.commit}</td>
-                              </tr>
-                            ) : null
-                          }
-                          {
-                            project.spec.workerTemplate.git.initSubmodules ? (
-                              <tr>
-                                <th>Initialize Submodules</th>
-                                <td>True</td>
-                              </tr>
-                            ) : null
-                          }
-                        </tbody>
-                      </Table>
-                    </td>
-                  </tr>
-                ) : null
-              }
+              {project.spec.workerTemplate.container?.image ? (
+                <tr>
+                  <th>Image</th>
+                  <td>{project.spec.workerTemplate.container?.image}</td>
+                </tr>
+              ) : null}
+              {project.spec.workerTemplate.git ? (
+                <tr>
+                  <th>Git</th>
+                  <td>
+                    <Table borderless hover>
+                      <tbody>
+                        {project.spec.workerTemplate.git.cloneURL ? (
+                          <tr>
+                            <th>Clone URL</th>
+                            <td>
+                              <Link
+                                to={project.spec.workerTemplate.git.cloneURL}
+                              >
+                                {project.spec.workerTemplate.git.cloneURL}
+                              </Link>
+                            </td>
+                          </tr>
+                        ) : null}
+                        {project.spec.workerTemplate.git.ref ? (
+                          <tr>
+                            <th>Ref</th>
+                            <td>{project.spec.workerTemplate.git.ref}</td>
+                          </tr>
+                        ) : null}
+                        {project.spec.workerTemplate.git.commit ? (
+                          <tr>
+                            <th>Commit</th>
+                            <td>{project.spec.workerTemplate.git.commit}</td>
+                          </tr>
+                        ) : null}
+                        {project.spec.workerTemplate.git.initSubmodules ? (
+                          <tr>
+                            <th>Initialize Submodules</th>
+                            <td>True</td>
+                          </tr>
+                        ) : null}
+                      </tbody>
+                    </Table>
+                  </td>
+                </tr>
+              ) : null}
             </tbody>
           </Table>
         </Card.Body>
       </Card>
     )
   }
-
 }

--- a/src/ProjectList.tsx
+++ b/src/ProjectList.tsx
@@ -22,8 +22,10 @@ interface ProjectListItemState {
   lastEventWorkerPhase?: core.WorkerPhase | null
 }
 
-class ProjectListItem extends React.Component<ProjectListItemProps, ProjectListItemState> {
-
+class ProjectListItem extends React.Component<
+  ProjectListItemProps,
+  ProjectListItemState
+> {
   constructor(props: ProjectListItemProps) {
     super(props)
     this.state = {}
@@ -34,7 +36,8 @@ class ProjectListItem extends React.Component<ProjectListItemProps, ProjectListI
       projectID: this.props.project.metadata.id
     })
     this.setState({
-      lastEventWorkerPhase: events.items?.length > 0 ? events.items[0].worker?.status.phase : null,
+      lastEventWorkerPhase:
+        events.items?.length > 0 ? events.items[0].worker?.status.phase : null
     })
   }
 
@@ -43,7 +46,8 @@ class ProjectListItem extends React.Component<ProjectListItemProps, ProjectListI
     return (
       <tr>
         <td>
-          <WorkerPhaseIcon phase={this.state.lastEventWorkerPhase}/>&nbsp;&nbsp;
+          <WorkerPhaseIcon phase={this.state.lastEventWorkerPhase} />
+          &nbsp;&nbsp;
           <Link to={linkTo}>{this.props.project.metadata.id}</Link>
         </td>
         <td>{this.props.project.description}</td>
@@ -51,15 +55,17 @@ class ProjectListItem extends React.Component<ProjectListItemProps, ProjectListI
       </tr>
     )
   }
-
 }
 
 export default withPagingControl(
-  (props: unknown, continueVal: string): Promise<meta.List<core.Project>>  => {
-    return getClient().core().projects().list({}, {
-      continue: continueVal,
-      limit: projectListPageSize
-    })
+  (props: unknown, continueVal: string): Promise<meta.List<core.Project>> => {
+    return getClient().core().projects().list(
+      {},
+      {
+        continue: continueVal,
+        limit: projectListPageSize
+      }
+    )
   },
   (projects: core.Project[]): React.ReactElement => {
     return (
@@ -72,11 +78,9 @@ export default withPagingControl(
           </tr>
         </thead>
         <tbody>
-          {
-            projects.map((project: core.Project) => (
-              <ProjectListItem key={project.metadata.id} project={project}/>
-            ))
-          }
+          {projects.map((project: core.Project) => (
+            <ProjectListItem key={project.metadata.id} project={project} />
+          ))}
         </tbody>
       </Table>
     )

--- a/src/ProjectPermissionsList.tsx
+++ b/src/ProjectPermissionsList.tsx
@@ -22,8 +22,10 @@ interface ProjectPermissionsListItemState {
   locked: boolean | null
 }
 
-class ProjectPermissionsListItem extends React.Component<ProjectPermissionsListItemProps, ProjectPermissionsListItemState> {
-
+class ProjectPermissionsListItem extends React.Component<
+  ProjectPermissionsListItemProps,
+  ProjectPermissionsListItemState
+> {
   constructor(props: ProjectPermissionsListItemProps) {
     super(props)
     this.state = {
@@ -34,41 +36,65 @@ class ProjectPermissionsListItem extends React.Component<ProjectPermissionsListI
   async componentDidMount(): Promise<void> {
     let locked: boolean | null = null
     switch (this.props.projectRoleAssignment.principal.type) {
-    case authz.PrincipalTypeServiceAccount:
-      locked = (await getClient().authn().serviceAccounts().get(this.props.projectRoleAssignment.principal.id)).locked? true : false
-      break
-    case authz.PrincipalTypeUser:
-      locked = (await getClient().authn().users().get(this.props.projectRoleAssignment.principal.id)).locked? true : false
-      break
+      case authz.PrincipalTypeServiceAccount:
+        locked = (
+          await getClient()
+            .authn()
+            .serviceAccounts()
+            .get(this.props.projectRoleAssignment.principal.id)
+        ).locked
+          ? true
+          : false
+        break
+      case authz.PrincipalTypeUser:
+        locked = (
+          await getClient()
+            .authn()
+            .users()
+            .get(this.props.projectRoleAssignment.principal.id)
+        ).locked
+          ? true
+          : false
+        break
     }
     this.setState({
       locked: locked
     })
   }
-  
+
   render(): React.ReactElement {
-    const principalLink = this.props.projectRoleAssignment.principal.type === authz.PrincipalTypeServiceAccount ? 
-      "/service-accounts/" + this.props.projectRoleAssignment.principal.id :
-      "/users/" + this.props.projectRoleAssignment.principal.id
-    const projectLink = "/projects/" + this.props.projectRoleAssignment.projectID
+    const principalLink =
+      this.props.projectRoleAssignment.principal.type ===
+      authz.PrincipalTypeServiceAccount
+        ? "/service-accounts/" + this.props.projectRoleAssignment.principal.id
+        : "/users/" + this.props.projectRoleAssignment.principal.id
+    const projectLink =
+      "/projects/" + this.props.projectRoleAssignment.projectID
     return (
       <tr>
-        { this.props.suppressPrincipalColumn ? null : (
+        {this.props.suppressPrincipalColumn ? null : (
           <td>
-            <PrincipalIcon principalType={this.props.projectRoleAssignment.principal.type} locked={this.state.locked}/>&nbsp;&nbsp;
-            <Link to={principalLink}>{this.props.projectRoleAssignment.principal.id}</Link>
+            <PrincipalIcon
+              principalType={this.props.projectRoleAssignment.principal.type}
+              locked={this.state.locked}
+            />
+            &nbsp;&nbsp;
+            <Link to={principalLink}>
+              {this.props.projectRoleAssignment.principal.id}
+            </Link>
           </td>
         )}
-        { this.props.suppressProjectColumn ? null : (
+        {this.props.suppressProjectColumn ? null : (
           <td>
-            <Link to={projectLink}>{this.props.projectRoleAssignment.projectID}</Link>
+            <Link to={projectLink}>
+              {this.props.projectRoleAssignment.projectID}
+            </Link>
           </td>
         )}
         <td>{this.props.projectRoleAssignment.role}</td>
       </tr>
     )
   }
-
 }
 
 interface ProjectPermissionsListProps {
@@ -77,35 +103,54 @@ interface ProjectPermissionsListProps {
 }
 
 export default withPagingControl(
-  (props: ProjectPermissionsListProps, continueVal: string): Promise<meta.List<core.ProjectRoleAssignment>>  => {
-    return getClient().core().projects().authz().roleAssignments().list(props.projectID || "", props.selector, {
-      continue: continueVal,
-      limit: permissionsListPageSize
-    })
+  (
+    props: ProjectPermissionsListProps,
+    continueVal: string
+  ): Promise<meta.List<core.ProjectRoleAssignment>> => {
+    return getClient()
+      .core()
+      .projects()
+      .authz()
+      .roleAssignments()
+      .list(props.projectID || "", props.selector, {
+        continue: continueVal,
+        limit: permissionsListPageSize
+      })
   },
-  (projectRoleAssignments: core.ProjectRoleAssignment[], props: ProjectPermissionsListProps): React.ReactElement => {
+  (
+    projectRoleAssignments: core.ProjectRoleAssignment[],
+    props: ProjectPermissionsListProps
+  ): React.ReactElement => {
     const suppressPrincipalColumn = props.selector?.principal ? true : false
     const suppressProjectColumn = props.projectID ? true : false
     return (
       <Table striped bordered hover responsive>
         <thead>
           <tr>
-            { suppressPrincipalColumn ? null : <th>Principal</th> }
-            { suppressProjectColumn ? null : <th>Project</th> }
+            {suppressPrincipalColumn ? null : <th>Principal</th>}
+            {suppressProjectColumn ? null : <th>Project</th>}
             <th>Role</th>
           </tr>
         </thead>
         <tbody>
-          {
-            projectRoleAssignments.map((projectRoleAssignment: core.ProjectRoleAssignment) => (
-              <ProjectPermissionsListItem 
-                key={projectRoleAssignment.principal.type + ":" + projectRoleAssignment.principal.id + ":" + projectRoleAssignment.projectID + ":" + projectRoleAssignment.role}
+          {projectRoleAssignments.map(
+            (projectRoleAssignment: core.ProjectRoleAssignment) => (
+              <ProjectPermissionsListItem
+                key={
+                  projectRoleAssignment.principal.type +
+                  ":" +
+                  projectRoleAssignment.principal.id +
+                  ":" +
+                  projectRoleAssignment.projectID +
+                  ":" +
+                  projectRoleAssignment.role
+                }
                 projectRoleAssignment={projectRoleAssignment}
                 suppressPrincipalColumn={suppressPrincipalColumn}
                 suppressProjectColumn={suppressProjectColumn}
               />
-            ))
-          }
+            )
+          )}
         </tbody>
       </Table>
     )

--- a/src/Projects.tsx
+++ b/src/Projects.tsx
@@ -3,14 +3,12 @@ import React from "react"
 import ProjectList from "./ProjectList"
 
 export default class Projects extends React.Component {
-
   render(): React.ReactElement {
     return (
       <div>
         <h1 className="page-heading">Projects</h1>
-        <ProjectList/>
+        <ProjectList />
       </div>
     )
   }
-
 }

--- a/src/SecretsList.tsx
+++ b/src/SecretsList.tsx
@@ -14,7 +14,6 @@ interface SecretListItemProps {
 }
 
 class SecretListItem extends React.Component<SecretListItemProps> {
-
   render(): React.ReactElement {
     return (
       <tr>
@@ -23,7 +22,6 @@ class SecretListItem extends React.Component<SecretListItemProps> {
       </tr>
     )
   }
-
 }
 
 interface SecretListProps {
@@ -31,7 +29,10 @@ interface SecretListProps {
 }
 
 export default withPagingControl(
-  (props: SecretListProps, continueVal: string): Promise<meta.List<core.Secret>>  => {
+  (
+    props: SecretListProps,
+    continueVal: string
+  ): Promise<meta.List<core.Secret>> => {
     return getClient().core().projects().secrets().list(props.projectID, {
       continue: continueVal,
       limit: secretListPageSize
@@ -47,11 +48,9 @@ export default withPagingControl(
           </tr>
         </thead>
         <tbody>
-          {
-            secrets.map((secret: core.Secret) => (
-              <SecretListItem key={secret.key} secret={secret}/>
-            ))
-          }
+          {secrets.map((secret: core.Secret) => (
+            <SecretListItem key={secret.key} secret={secret} />
+          ))}
         </tbody>
       </Table>
     )

--- a/src/ServiceAccount.tsx
+++ b/src/ServiceAccount.tsx
@@ -26,8 +26,10 @@ interface ServiceAccountState {
 }
 
 // TODO: Need to make this component auto-refresh
-class ServiceAccount extends React.Component<ServiceAccountProps, ServiceAccountState> {
-
+class ServiceAccount extends React.Component<
+  ServiceAccountProps,
+  ServiceAccountState
+> {
   constructor(props: ServiceAccountProps) {
     super(props)
     this.state = {}
@@ -35,38 +37,51 @@ class ServiceAccount extends React.Component<ServiceAccountProps, ServiceAccount
 
   async componentDidMount(): Promise<void> {
     this.setState({
-      serviceAccount: await getClient().authn().serviceAccounts().get(this.props.id)
+      serviceAccount: await getClient()
+        .authn()
+        .serviceAccounts()
+        .get(this.props.id)
     })
   }
 
   render(): React.ReactElement {
     const serviceAccount = this.state.serviceAccount
     if (!serviceAccount) {
-      return <Spinner/>
+      return <Spinner />
     }
     return (
       <div>
         <h1 className="page-heading">{serviceAccount?.metadata.id}</h1>
         <Tabs defaultActiveKey="summary" className="mb-3" mountOnEnter={true}>
           <Tab eventKey="summary" title="Summary">
-            <ServiceAccountSummary serviceAccount={serviceAccount}/>
+            <ServiceAccountSummary serviceAccount={serviceAccount} />
           </Tab>
           <Tab eventKey="system-permissions" title="System Permissions">
-            <SystemPermissionsList selector={{principal: {type: authz.PrincipalTypeServiceAccount, id: this.props.id}}}/>
+            <SystemPermissionsList
+              selector={{
+                principal: {
+                  type: authz.PrincipalTypeServiceAccount,
+                  id: this.props.id
+                }
+              }}
+            />
           </Tab>
           <Tab eventKey="project-permissions" title="Project Permissions">
-            <ProjectPermissionsList selector={{principal: {type: authz.PrincipalTypeUser, id: this.props.id}}}/>
+            <ProjectPermissionsList
+              selector={{
+                principal: { type: authz.PrincipalTypeUser, id: this.props.id }
+              }}
+            />
           </Tab>
         </Tabs>
       </div>
     )
   }
-
 }
 
 export default function RoutedServiceAccount(): React.ReactElement {
   const params: any = useParams() // eslint-disable-line @typescript-eslint/no-explicit-any
-  return <ServiceAccount id={params.id}/>
+  return <ServiceAccount id={params.id} />
 }
 
 interface ServiceAccountSummaryProps {
@@ -74,13 +89,12 @@ interface ServiceAccountSummaryProps {
 }
 
 class ServiceAccountSummary extends React.Component<ServiceAccountSummaryProps> {
-
   render(): React.ReactElement {
     const serviceAccount = this.props.serviceAccount
     return (
       <Card border={serviceAccount.locked ? "danger" : "success"} bg="light">
         <Card.Header>
-          <LockIcon locked={serviceAccount.locked ? true : false}/>
+          <LockIcon locked={serviceAccount.locked ? true : false} />
           &nbsp;&nbsp;
           {serviceAccount?.metadata.id}
         </Card.Header>
@@ -93,7 +107,11 @@ class ServiceAccountSummary extends React.Component<ServiceAccountSummaryProps> 
               </tr>
               <tr>
                 <th>Created</th>
-                <td>{moment(serviceAccount.metadata.created).format("YYYY-MM-DD HH:mm:ss Z")}</td>
+                <td>
+                  {moment(serviceAccount.metadata.created).format(
+                    "YYYY-MM-DD HH:mm:ss Z"
+                  )}
+                </td>
               </tr>
             </tbody>
           </Table>
@@ -101,5 +119,4 @@ class ServiceAccountSummary extends React.Component<ServiceAccountSummaryProps> 
       </Card>
     )
   }
-
 }

--- a/src/ServiceAccountList.tsx
+++ b/src/ServiceAccountList.tsx
@@ -19,10 +19,16 @@ interface ServiceAccountListItemProps {
 }
 
 class ServiceAccountListItem extends React.Component<ServiceAccountListItemProps> {
-
   refresh = async () => {
     this.setState({
-      locked: (await getClient().authn().serviceAccounts().get(this.props.serviceAccount.metadata.id)).locked ? true : false
+      locked: (
+        await getClient()
+          .authn()
+          .serviceAccounts()
+          .get(this.props.serviceAccount.metadata.id)
+      ).locked
+        ? true
+        : false
     })
   }
 
@@ -36,22 +42,31 @@ class ServiceAccountListItem extends React.Component<ServiceAccountListItemProps
     return (
       <tr>
         <td>
-          <LockIcon locked={serviceAccount.locked ? true : false}/>&nbsp;&nbsp;
+          <LockIcon locked={serviceAccount.locked ? true : false} />
+          &nbsp;&nbsp;
           <Link to={linkTo}>{this.props.serviceAccount.metadata.id}</Link>
         </td>
         <td>{this.props.serviceAccount.description}</td>
-        <td>{moment(this.props.serviceAccount.metadata.created).fromNow(true)}</td>
+        <td>
+          {moment(this.props.serviceAccount.metadata.created).fromNow(true)}
+        </td>
       </tr>
     )
   }
 }
 
 export default withPagingControl(
-  (props: unknown, continueVal: string): Promise<meta.List<authn.ServiceAccount>>  => {
-    return getClient().authn().serviceAccounts().list({}, {
-      continue: continueVal,
-      limit: serviceAccountListPageSize
-    })
+  (
+    props: unknown,
+    continueVal: string
+  ): Promise<meta.List<authn.ServiceAccount>> => {
+    return getClient().authn().serviceAccounts().list(
+      {},
+      {
+        continue: continueVal,
+        limit: serviceAccountListPageSize
+      }
+    )
   },
   (serviceAccounts: authn.ServiceAccount[]): React.ReactElement => {
     return (
@@ -64,11 +79,12 @@ export default withPagingControl(
           </tr>
         </thead>
         <tbody>
-          {
-            serviceAccounts.map((serviceAccount: authn.ServiceAccount) => (
-              <ServiceAccountListItem key={serviceAccount.metadata.id} serviceAccount={serviceAccount}/>
-            ))
-          }
+          {serviceAccounts.map((serviceAccount: authn.ServiceAccount) => (
+            <ServiceAccountListItem
+              key={serviceAccount.metadata.id}
+              serviceAccount={serviceAccount}
+            />
+          ))}
         </tbody>
       </Table>
     )

--- a/src/ServiceAccounts.tsx
+++ b/src/ServiceAccounts.tsx
@@ -3,14 +3,12 @@ import React from "react"
 import ServiceAccountList from "./ServiceAccountList"
 
 export default class ServiceAccounts extends React.Component {
-
   render(): React.ReactElement {
     return (
       <div>
         <h1 className="page-heading">Service Accounts</h1>
-        <ServiceAccountList/>
+        <ServiceAccountList />
       </div>
     )
   }
-
 }

--- a/src/SystemPermissions.tsx
+++ b/src/SystemPermissions.tsx
@@ -3,14 +3,12 @@ import React from "react"
 import SystemPermissionsList from "./SystemPermissionsList"
 
 export default class SystemPermissions extends React.Component {
-
   render(): React.ReactElement {
     return (
       <div>
         <h1 className="page-heading">System Permissions</h1>
-        <SystemPermissionsList/>
+        <SystemPermissionsList />
       </div>
     )
   }
-
 }

--- a/src/SystemPermissionsList.tsx
+++ b/src/SystemPermissionsList.tsx
@@ -23,8 +23,10 @@ interface SystemPermissionsListItemState {
   locked: boolean | null
 }
 
-class SystemPermissionsListItem extends React.Component<SystemPermissionsListItemProps, SystemPermissionsListItemState> {
-
+class SystemPermissionsListItem extends React.Component<
+  SystemPermissionsListItemProps,
+  SystemPermissionsListItemState
+> {
   constructor(props: SystemPermissionsListItemProps) {
     super(props)
     this.state = {
@@ -36,12 +38,26 @@ class SystemPermissionsListItem extends React.Component<SystemPermissionsListIte
     if (!this.props.suppressPrincipalColumn) {
       let locked: boolean | null = null
       switch (this.props.roleAssignment.principal.type) {
-      case authz.PrincipalTypeServiceAccount:
-        locked = (await getClient().authn().serviceAccounts().get(this.props.roleAssignment.principal.id)).locked? true : false
-        break
-      case authz.PrincipalTypeUser:
-        locked = (await getClient().authn().users().get(this.props.roleAssignment.principal.id)).locked? true : false
-        break
+        case authz.PrincipalTypeServiceAccount:
+          locked = (
+            await getClient()
+              .authn()
+              .serviceAccounts()
+              .get(this.props.roleAssignment.principal.id)
+          ).locked
+            ? true
+            : false
+          break
+        case authz.PrincipalTypeUser:
+          locked = (
+            await getClient()
+              .authn()
+              .users()
+              .get(this.props.roleAssignment.principal.id)
+          ).locked
+            ? true
+            : false
+          break
       }
       this.setState({
         locked: locked
@@ -50,14 +66,20 @@ class SystemPermissionsListItem extends React.Component<SystemPermissionsListIte
   }
 
   render(): React.ReactElement {
-    const linkTo = this.props.roleAssignment.principal.type === authz.PrincipalTypeServiceAccount ? 
-      "/service-accounts/" + this.props.roleAssignment.principal.id :
-      "/users/" + this.props.roleAssignment.principal.id
+    const linkTo =
+      this.props.roleAssignment.principal.type ===
+      authz.PrincipalTypeServiceAccount
+        ? "/service-accounts/" + this.props.roleAssignment.principal.id
+        : "/users/" + this.props.roleAssignment.principal.id
     return (
       <tr>
-        { this.props.suppressPrincipalColumn ? null : (
+        {this.props.suppressPrincipalColumn ? null : (
           <td>
-            <PrincipalIcon principalType={this.props.roleAssignment.principal.type} locked={this.state.locked}/>&nbsp;&nbsp;
+            <PrincipalIcon
+              principalType={this.props.roleAssignment.principal.type}
+              locked={this.state.locked}
+            />
+            &nbsp;&nbsp;
             <Link to={linkTo}>{this.props.roleAssignment.principal.id}</Link>
           </td>
         )}
@@ -66,7 +88,6 @@ class SystemPermissionsListItem extends React.Component<SystemPermissionsListIte
       </tr>
     )
   }
-
 }
 
 interface SystemPermissionsListProps {
@@ -74,33 +95,43 @@ interface SystemPermissionsListProps {
 }
 
 export default withPagingControl(
-  (props: SystemPermissionsListProps, continueVal: string): Promise<meta.List<libAuthz.RoleAssignment>>  => {
+  (
+    props: SystemPermissionsListProps,
+    continueVal: string
+  ): Promise<meta.List<libAuthz.RoleAssignment>> => {
     return getClient().authz().roleAssignments().list(props.selector, {
       continue: continueVal,
       limit: permissionsListPageSize
     })
   },
-  (roleAssignments: libAuthz.RoleAssignment[], props: SystemPermissionsListProps): React.ReactElement => {
+  (
+    roleAssignments: libAuthz.RoleAssignment[],
+    props: SystemPermissionsListProps
+  ): React.ReactElement => {
     const suppressPrincipalColumn = props.selector?.principal ? true : false
     return (
       <Table striped bordered hover responsive>
         <thead>
           <tr>
-            { suppressPrincipalColumn ? null : <th>Principal</th> }
+            {suppressPrincipalColumn ? null : <th>Principal</th>}
             <th>Role</th>
             <th>Scope</th>
           </tr>
         </thead>
         <tbody>
-          {
-            roleAssignments.map((roleAssignment: libAuthz.RoleAssignment) => (
-              <SystemPermissionsListItem 
-                key={roleAssignment.principal.type + ":" + roleAssignment.principal.id + ":" + roleAssignment.role}
-                roleAssignment={roleAssignment}
-                suppressPrincipalColumn={suppressPrincipalColumn}
-              />
-            ))
-          }
+          {roleAssignments.map((roleAssignment: libAuthz.RoleAssignment) => (
+            <SystemPermissionsListItem
+              key={
+                roleAssignment.principal.type +
+                ":" +
+                roleAssignment.principal.id +
+                ":" +
+                roleAssignment.role
+              }
+              roleAssignment={roleAssignment}
+              suppressPrincipalColumn={suppressPrincipalColumn}
+            />
+          ))}
         </tbody>
       </Table>
     )

--- a/src/User.tsx
+++ b/src/User.tsx
@@ -27,7 +27,6 @@ interface UserState {
 
 // TODO: Need to make this component auto-refresh
 class User extends React.Component<UserProps, UserState> {
-
   constructor(props: UserProps) {
     super(props)
     this.state = {}
@@ -42,31 +41,38 @@ class User extends React.Component<UserProps, UserState> {
   render(): React.ReactElement {
     const user = this.state.user
     if (!user) {
-      return <Spinner/>
+      return <Spinner />
     }
     return (
       <div>
         <h1 className="page-heading">{user?.metadata.id}</h1>
         <Tabs defaultActiveKey="summary" className="mb-3" mountOnEnter={true}>
           <Tab eventKey="summary" title="Summary">
-            <UserSummary user={user}/>
+            <UserSummary user={user} />
           </Tab>
           <Tab eventKey="system-permissions" title="System Permissions">
-            <SystemPermissionsList selector={{principal: {type: authz.PrincipalTypeUser, id: this.props.id}}}/>
+            <SystemPermissionsList
+              selector={{
+                principal: { type: authz.PrincipalTypeUser, id: this.props.id }
+              }}
+            />
           </Tab>
           <Tab eventKey="project-permissions" title="Project Permissions">
-            <ProjectPermissionsList selector={{principal: {type: authz.PrincipalTypeUser, id: this.props.id}}}/>
+            <ProjectPermissionsList
+              selector={{
+                principal: { type: authz.PrincipalTypeUser, id: this.props.id }
+              }}
+            />
           </Tab>
         </Tabs>
       </div>
     )
   }
-
 }
 
 export default function RoutedUser(): React.ReactElement {
   const params: any = useParams() // eslint-disable-line @typescript-eslint/no-explicit-any
-  return <User id={params.id}/>
+  return <User id={params.id} />
 }
 
 interface UserSummaryProps {
@@ -74,13 +80,12 @@ interface UserSummaryProps {
 }
 
 class UserSummary extends React.Component<UserSummaryProps> {
-
   render(): React.ReactElement {
     const user = this.props.user
     return (
       <Card border={user.locked ? "danger" : "success"} bg="light">
         <Card.Header>
-          <LockIcon locked={user.locked ? true : false}/>
+          <LockIcon locked={user.locked ? true : false} />
           &nbsp;&nbsp;
           {user?.metadata.id}
         </Card.Header>
@@ -93,7 +98,11 @@ class UserSummary extends React.Component<UserSummaryProps> {
               </tr>
               <tr>
                 <th>First Login</th>
-                <td>{moment(user.metadata.created).format("YYYY-MM-DD HH:mm:ss Z")}</td>
+                <td>
+                  {moment(user.metadata.created).format(
+                    "YYYY-MM-DD HH:mm:ss Z"
+                  )}
+                </td>
               </tr>
             </tbody>
           </Table>
@@ -101,5 +110,4 @@ class UserSummary extends React.Component<UserSummaryProps> {
       </Card>
     )
   }
-
 }

--- a/src/UserList.tsx
+++ b/src/UserList.tsx
@@ -19,14 +19,14 @@ interface UserListItemProps {
 }
 
 class UserListItem extends React.Component<UserListItemProps> {
-
   render(): React.ReactElement {
     const user = this.props.user
     const linkTo = "/users/" + this.props.user.metadata.id
     return (
       <tr>
         <td>
-          <LockIcon locked={user.locked ? true : false}/>&nbsp;&nbsp;
+          <LockIcon locked={user.locked ? true : false} />
+          &nbsp;&nbsp;
           <Link to={linkTo}>{this.props.user.metadata.id}</Link>
         </td>
         <td>{this.props.user.name}</td>
@@ -37,11 +37,14 @@ class UserListItem extends React.Component<UserListItemProps> {
 }
 
 export default withPagingControl(
-  (props: unknown, continueVal: string): Promise<meta.List<authn.User>>  => {
-    return getClient().authn().users().list({}, {
-      continue: continueVal,
-      limit: userListPageSize
-    })
+  (props: unknown, continueVal: string): Promise<meta.List<authn.User>> => {
+    return getClient().authn().users().list(
+      {},
+      {
+        continue: continueVal,
+        limit: userListPageSize
+      }
+    )
   },
   (users: authn.User[]): React.ReactElement => {
     return (
@@ -54,11 +57,9 @@ export default withPagingControl(
           </tr>
         </thead>
         <tbody>
-          {
-            users.map((user: authn.User) => (
-              <UserListItem key={user.metadata.id} user={user}/>
-            ))
-          }
+          {users.map((user: authn.User) => (
+            <UserListItem key={user.metadata.id} user={user} />
+          ))}
         </tbody>
       </Table>
     )

--- a/src/Users.tsx
+++ b/src/Users.tsx
@@ -3,14 +3,12 @@ import React from "react"
 import UserList from "./UserList"
 
 export default class Users extends React.Component {
-
   render(): React.ReactElement {
     return (
       <div>
         <h1 className="page-heading">Users</h1>
-        <UserList/>
+        <UserList />
       </div>
     )
   }
-
 }

--- a/src/WorkerPhaseIcon.tsx
+++ b/src/WorkerPhaseIcon.tsx
@@ -1,4 +1,10 @@
-import { faCheck, faClock, faPlay, faQuestion, faTimes } from "@fortawesome/free-solid-svg-icons"
+import {
+  faCheck,
+  faClock,
+  faPlay,
+  faQuestion,
+  faTimes
+} from "@fortawesome/free-solid-svg-icons"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 
 import React from "react"
@@ -12,52 +18,50 @@ interface WorkerPhaseIconProps {
 }
 
 export default class WorkerPhaseIcon extends React.Component<WorkerPhaseIconProps> {
-
   render(): React.ReactElement {
     if (this.props.phase === undefined) {
-      return <Spinner animation="border" size="sm"/>
+      return <Spinner animation="border" size="sm" />
     }
     let icon = faQuestion
     let color = "dimgray"
-    switch(this.props.phase) {
-    case core.WorkerPhase.Aborted:
-      icon = faTimes
-      color = "firebrick"
-      break
-    case core.WorkerPhase.Canceled:
-      icon = faTimes
-      color = "firebrick"
-      break
-    case core.WorkerPhase.Failed:
-      icon = faTimes
-      color = "firebrick"
-      break
-    case core.WorkerPhase.Pending:
-      icon = faClock
-      color = "goldenrod"
-      break
-    case core.WorkerPhase.Running:
-      icon = faPlay
-      color = "goldenrod"
-      break
-    case core.WorkerPhase.SchedulingFailed:
-      icon = faTimes
-      color = "firebrick"
-      break
-    case core.WorkerPhase.Starting:
-      icon = faPlay
-      color = "goldenrod"
-      break
-    case core.WorkerPhase.Succeeded:
-      icon = faCheck
-      color = "green"
-      break
-    case core.WorkerPhase.TimedOut:
-      icon = faTimes
-      color = "firebrick"
-      break
+    switch (this.props.phase) {
+      case core.WorkerPhase.Aborted:
+        icon = faTimes
+        color = "firebrick"
+        break
+      case core.WorkerPhase.Canceled:
+        icon = faTimes
+        color = "firebrick"
+        break
+      case core.WorkerPhase.Failed:
+        icon = faTimes
+        color = "firebrick"
+        break
+      case core.WorkerPhase.Pending:
+        icon = faClock
+        color = "goldenrod"
+        break
+      case core.WorkerPhase.Running:
+        icon = faPlay
+        color = "goldenrod"
+        break
+      case core.WorkerPhase.SchedulingFailed:
+        icon = faTimes
+        color = "firebrick"
+        break
+      case core.WorkerPhase.Starting:
+        icon = faPlay
+        color = "goldenrod"
+        break
+      case core.WorkerPhase.Succeeded:
+        icon = faCheck
+        color = "green"
+        break
+      case core.WorkerPhase.TimedOut:
+        icon = faTimes
+        color = "firebrick"
+        break
     }
-    return <FontAwesomeIcon icon={icon} color={color}/>
+    return <FontAwesomeIcon icon={icon} color={color} />
   }
-
 }

--- a/src/components/LockIcon.tsx
+++ b/src/components/LockIcon.tsx
@@ -8,12 +8,10 @@ interface LockIconProps {
 }
 
 export default class LockIcon extends React.Component<LockIconProps> {
-
   render(): React.ReactElement {
-    if (this.props.locked) { 
-      return <FontAwesomeIcon icon={faLock} color="firebrick"/>
+    if (this.props.locked) {
+      return <FontAwesomeIcon icon={faLock} color="firebrick" />
     }
-    return <FontAwesomeIcon icon={faUnlockAlt} color="green"/>
+    return <FontAwesomeIcon icon={faUnlockAlt} color="green" />
   }
-
 }

--- a/src/components/LogStreamer.tsx
+++ b/src/components/LogStreamer.tsx
@@ -14,7 +14,6 @@ interface LogStreamerProps {
 }
 
 export default class LogStreamer extends React.Component<LogStreamerProps> {
-
   logStream?: core.LogEntryStream
   logBoxID: string
 
@@ -28,15 +27,16 @@ export default class LogStreamer extends React.Component<LogStreamerProps> {
     const event = this.props.event
     if (event.metadata?.id) {
       this.logStream = logsClient.stream(
-        event.metadata?.id, {
+        event.metadata?.id,
+        {
           job: this.props.jobName,
           container: this.props.containerName
         },
-        {follow: true}
+        { follow: true }
       )
       const logBox = document.getElementById(this.logBoxID)
       if (logBox) {
-        this.logStream.onData((logEntry: core.LogEntry) => {  
+        this.logStream.onData((logEntry: core.LogEntry) => {
           logBox.innerHTML += logEntry.message + "<br/>"
         })
       }
@@ -50,9 +50,6 @@ export default class LogStreamer extends React.Component<LogStreamerProps> {
   }
 
   render(): React.ReactElement {
-    return (
-      <pre id={this.logBoxID} className={styles["log-box"]}/>
-    )
+    return <pre id={this.logBoxID} className={styles["log-box"]} />
   }
-
 }

--- a/src/components/NextButton.tsx
+++ b/src/components/NextButton.tsx
@@ -10,9 +10,11 @@ interface NextButtonProps {
 }
 
 export default class NextButton extends React.Component<NextButtonProps> {
-
   render(): React.ReactElement {
-    return <Button onClick={this.props.onClick}>Next <FontAwesomeIcon icon={faChevronRight}/></Button>
+    return (
+      <Button onClick={this.props.onClick}>
+        Next <FontAwesomeIcon icon={faChevronRight} />
+      </Button>
+    )
   }
-
 }

--- a/src/components/PagingControl.tsx
+++ b/src/components/PagingControl.tsx
@@ -15,7 +15,7 @@ interface Page<T> {
 
 interface PagingControlState<T> {
   prevContinueVals: string[]
-  currentContinueVal: string,
+  currentContinueVal: string
   items: T[]
   nextContinueVal?: string
 }
@@ -25,9 +25,7 @@ export default function withPagingControl<T, T1>(
   fetch: (props: T, continueVal: string) => Promise<Page<T1>>,
   render: (items: T1[], props: T) => React.ReactElement
 ) {
-
   return class extends React.Component<T, PagingControlState<T1>> {
-    
     constructor(props: T) {
       super(props)
       this.state = {
@@ -41,7 +39,8 @@ export default function withPagingControl<T, T1>(
       const page = await fetch(this.props, "")
       this.setState({
         items: page.items,
-        nextContinueVal: page.metadata.continue === "" ? undefined : page.metadata.continue
+        nextContinueVal:
+          page.metadata.continue === "" ? undefined : page.metadata.continue
       })
     }
 
@@ -54,7 +53,8 @@ export default function withPagingControl<T, T1>(
           prevContinueVals: prevContinueVals,
           currentContinueVal: currentContinueVal,
           items: page.items,
-          nextContinueVal: page.metadata.continue === "" ? undefined : page.metadata.continue
+          nextContinueVal:
+            page.metadata.continue === "" ? undefined : page.metadata.continue
         })
       }
     }
@@ -70,7 +70,8 @@ export default function withPagingControl<T, T1>(
           prevContinueVals: prevContinueVals,
           currentContinueVal: currentContinueVal,
           items: page.items,
-          nextContinueVal: page.metadata.continue === "" ? undefined : page.metadata.continue
+          nextContinueVal:
+            page.metadata.continue === "" ? undefined : page.metadata.continue
         })
       }
     }
@@ -78,24 +79,22 @@ export default function withPagingControl<T, T1>(
     render(): React.ReactElement {
       const items = this.state.items
       if (!items) {
-        return <div/>
+        return <div />
       }
       if (items.length === 0) {
-        return <Spinner/>
+        return <Spinner />
       }
       const hasPrev = this.state.prevContinueVals.length > 0
       const hasMore = this.state.nextContinueVal ? true : false
       return (
         <div>
-          { render(items, this.props) }
+          {render(items, this.props)}
           <div className={styles["paging-controls"]}>
-            { hasPrev && <PreviousButton onClick={this.fetchPreviousPage}/> }
-            { hasMore && <NextButton onClick={this.fetchNextPage}/> }
+            {hasPrev && <PreviousButton onClick={this.fetchPreviousPage} />}
+            {hasMore && <NextButton onClick={this.fetchNextPage} />}
           </div>
         </div>
       )
     }
-
   }
-
 }

--- a/src/components/PreviousButton.tsx
+++ b/src/components/PreviousButton.tsx
@@ -10,9 +10,11 @@ interface PreviousButtonProps {
 }
 
 export default class PreviousButton extends React.Component<PreviousButtonProps> {
-
   render(): React.ReactElement {
-    return <Button onClick={this.props.onClick}><FontAwesomeIcon icon={faChevronLeft}/> Previous</Button>
+    return (
+      <Button onClick={this.props.onClick}>
+        <FontAwesomeIcon icon={faChevronLeft} /> Previous
+      </Button>
+    )
   }
-
 }

--- a/src/components/Spinner.tsx
+++ b/src/components/Spinner.tsx
@@ -5,13 +5,11 @@ import BootstrapSpinner from "react-bootstrap/Spinner"
 import styles from "./Spinner.module.scss"
 
 export default class Spinner extends React.Component {
-
   render(): React.ReactElement {
     return (
       <div className={styles["spinner-wrapper"]}>
-        <BootstrapSpinner animation="border" variant="primary"/>
+        <BootstrapSpinner animation="border" variant="primary" />
       </div>
     )
   }
-
 }

--- a/src/components/YAMLViewer.tsx
+++ b/src/components/YAMLViewer.tsx
@@ -13,7 +13,6 @@ interface YAMLViewerProps<T> {
 }
 
 export default class YAMLViewer<T> extends React.Component<YAMLViewerProps<T>> {
-
   render(): React.ReactElement {
     return (
       <SyntaxHighlighter language="yaml" style={style}>
@@ -21,5 +20,4 @@ export default class YAMLViewer<T> extends React.Component<YAMLViewerProps<T>> {
       </SyntaxHighlighter>
     )
   }
-
 }

--- a/src/home/BlogCard.tsx
+++ b/src/home/BlogCard.tsx
@@ -7,7 +7,6 @@ import rssEnhancer, { InjectionRSSProps } from "react-rss"
 import Card from "react-bootstrap/Card"
 
 class BlogCard extends React.Component<InjectionRSSProps> {
-  
   render(): React.ReactElement {
     const latest = this.props.rss.items[0]
     const date = moment(Date.parse(latest.pubDate)).format("DD MMM YYYY")
@@ -17,17 +16,21 @@ class BlogCard extends React.Component<InjectionRSSProps> {
         <Card.Body>
           <Card.Title>{latest.title}</Card.Title>
           <Card.Subtitle className="text-muted">{date}</Card.Subtitle>
-          <Card.Text dangerouslySetInnerHTML={{ __html: latest.description }}/>
-          <Card.Link href={latest.link} target="_blank">Read more</Card.Link>
+          <Card.Text dangerouslySetInnerHTML={{ __html: latest.description }} />
+          <Card.Link href={latest.link} target="_blank">
+            Read more
+          </Card.Link>
         </Card.Body>
       </Card>
     )
   }
-
 }
 
 export default rssEnhancer(
-  BlogCard, 
+  BlogCard,
   "https://blog.brigade.sh/index.xml",
-  url => ({ input: url, init: { headers: { "Origin": window.location.origin } } })
+  (url) => ({
+    input: url,
+    init: { headers: { Origin: window.location.origin } }
+  })
 )

--- a/src/home/ContributeCard.tsx
+++ b/src/home/ContributeCard.tsx
@@ -6,24 +6,26 @@ import React from "react"
 import Card from "react-bootstrap/Card"
 
 export default class ContributeCard extends React.Component {
-
   render(): React.ReactElement {
     return (
       <Card bg="light">
-        <Card.Header>
-          Contribute
-        </Card.Header>
+        <Card.Header>Contribute</Card.Header>
         <Card.Body>
           <ul className="links">
             <li>
-              <FontAwesomeIcon icon={faGithub}/>
+              <FontAwesomeIcon icon={faGithub} />
               &nbsp;&nbsp;
-              <a href="https://github.com/brigadecore" target="_blank" rel="noreferrer">Check us out on GitHub!</a>
+              <a
+                href="https://github.com/brigadecore"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Check us out on GitHub!
+              </a>
             </li>
           </ul>
         </Card.Body>
       </Card>
     )
   }
-
 }

--- a/src/home/ResourcesCard.tsx
+++ b/src/home/ResourcesCard.tsx
@@ -1,4 +1,8 @@
-import { faSlack, faTwitter, faYoutube } from "@fortawesome/free-brands-svg-icons"
+import {
+  faSlack,
+  faTwitter,
+  faYoutube
+} from "@fortawesome/free-brands-svg-icons"
 import { faBlog, faBook } from "@fortawesome/free-solid-svg-icons"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 
@@ -9,57 +13,101 @@ import Card from "react-bootstrap/Card"
 import styles from "./ResourcesCard.module.scss"
 
 export default class ResourcesCard extends React.Component {
-
   render(): React.ReactElement {
     return (
       <Card bg="light">
-        <Card.Header>
-          Resources
-        </Card.Header>
+        <Card.Header>Resources</Card.Header>
         <Card.Body>
           <ul className={styles.links}>
             <li>
-              <FontAwesomeIcon icon={faBook}/>
+              <FontAwesomeIcon icon={faBook} />
               &nbsp;&nbsp;
-              <a href="https://docs.brigade.sh/" target="_blank" rel="noreferrer">Documentation</a>
+              <a
+                href="https://docs.brigade.sh/"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Documentation
+              </a>
               <ul>
                 <li>
-                  <a href="https://quickstart.brigade.sh/" target="_blank" rel="noreferrer">QuickStart</a>
+                  <a
+                    href="https://quickstart.brigade.sh/"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    QuickStart
+                  </a>
                 </li>
               </ul>
             </li>
             <li>
-              <FontAwesomeIcon icon={faBlog}/>
+              <FontAwesomeIcon icon={faBlog} />
               &nbsp;&nbsp;
-              <a href="https://blog.brigade.sh/" target="_blank" rel="noreferrer">Blog</a>
+              <a
+                href="https://blog.brigade.sh/"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Blog
+              </a>
             </li>
             <li>
-              <FontAwesomeIcon icon={faYoutube}/>
+              <FontAwesomeIcon icon={faYoutube} />
               &nbsp;&nbsp;
-              <a href="https://youtube.brigade.sh/" target="_blank" rel="noreferrer">YouTube Channel</a>
+              <a
+                href="https://youtube.brigade.sh/"
+                target="_blank"
+                rel="noreferrer"
+              >
+                YouTube Channel
+              </a>
               <ul>
                 <li>
-                  <a href="https://www.youtube.com/watch?v=VFyvYOjm6zc" target="_blank" rel="noreferrer">Video QuickStart</a>
+                  <a
+                    href="https://www.youtube.com/watch?v=VFyvYOjm6zc"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    Video QuickStart
+                  </a>
                 </li>
                 <li>
-                  <a href="https://www.youtube.com/playlist?list=PLUfRhEZrmeaSWQCvOSs3bbq1NpbSVCW6v" target="_blank" rel="noreferrer">Brigade in 5 Minutes Series</a>
+                  <a
+                    href="https://www.youtube.com/playlist?list=PLUfRhEZrmeaSWQCvOSs3bbq1NpbSVCW6v"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    Brigade in 5 Minutes Series
+                  </a>
                 </li>
               </ul>
             </li>
             <li>
-              <FontAwesomeIcon icon={faSlack}/>
+              <FontAwesomeIcon icon={faSlack} />
               &nbsp;&nbsp;
-              <a href="https://slack.brigade.sh/" target="_blank" rel="noreferrer">Slack Channel</a>
+              <a
+                href="https://slack.brigade.sh/"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Slack Channel
+              </a>
             </li>
             <li>
-              <FontAwesomeIcon icon={faTwitter}/>
+              <FontAwesomeIcon icon={faTwitter} />
               &nbsp;&nbsp;
-              <a href="https://twitter.com/brigadecore/" target="_blank" rel="noreferrer">Twitter Channel</a>
+              <a
+                href="https://twitter.com/brigadecore/"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Twitter Channel
+              </a>
             </li>
           </ul>
         </Card.Body>
       </Card>
     )
   }
-
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -22,18 +22,18 @@ ReactDOM.render(
   <React.StrictMode>
     <BrowserRouter>
       <Routes>
-        <Route path="/" element={<App/>}>
-          <Route index element={<Home/>}/>
-          <Route path="projects" element={<Projects/>}/>
-          <Route path="projects/:id" element={<Project/>}/>
-          <Route path="events" element={<Events/>}/>
-          <Route path="events/:id" element={<Event/>}/>
-          <Route path="users" element={<Users/>}/>
-          <Route path="users/:id" element={<User/>}/>
-          <Route path="service-accounts" element={<ServiceAccounts/>}/>
-          <Route path="service-accounts/:id" element={<ServiceAccount/>}/>
-          <Route path="system-permissions" element={<SystemPermissions/>}/>
-          <Route path="*" element={<h1 className="page-heading">404</h1>}/>
+        <Route path="/" element={<App />}>
+          <Route index element={<Home />} />
+          <Route path="projects" element={<Projects />} />
+          <Route path="projects/:id" element={<Project />} />
+          <Route path="events" element={<Events />} />
+          <Route path="events/:id" element={<Event />} />
+          <Route path="users" element={<Users />} />
+          <Route path="users/:id" element={<User />} />
+          <Route path="service-accounts" element={<ServiceAccounts />} />
+          <Route path="service-accounts/:id" element={<ServiceAccount />} />
+          <Route path="system-permissions" element={<SystemPermissions />} />
+          <Route path="*" element={<h1 className="page-heading">404</h1>} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -20,7 +16,5 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3962,6 +3962,11 @@ escodegen@^2.0.0:
   optionalDependencies:
     source-map "~0.6.1"
 
+eslint-config-prettier@^8.5.0:
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz#5a81680ec934beca02c7b1a61cf8ca34b66feab1"
+  integrity sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==
+
 eslint-config-react-app@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/eslint-config-react-app/-/eslint-config-react-app-7.0.0.tgz#0fa96d5ec1dfb99c029b1554362ab3fa1c3757df"
@@ -7234,6 +7239,11 @@ prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
+
+prettier@2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.5.1.tgz#fff75fa9d519c54cf0fce328c1017d94546bc56a"
+  integrity sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==
 
 pretty-bytes@^5.3.0, pretty-bytes@^5.4.1:
   version "5.6.0"


### PR DESCRIPTION
Fixes #39 

Follow-up to #37 

This PR does the following:

* Sets up [prettier](https://prettier.io/) to help us enforce an opinionated coding style
* Configures the linter to not conflict with choices made by prettier
    * prettier will enforce _style_ choices; linter will still be used to detect _other issues_
* Adds scripts to `package.json`:
    * `style:check`:  Check formatting
    * `style:fix`: Fix formatting. For folks with prettier integaration in their editor / IDE (for instance, I'm using [prettier-vscode](https://github.com/prettier/prettier-vscode)) style violations can be fixed automatically when files are saved. Undoubtedly, not every contributor will have this set up -- which is why this script exists. When someone's contributions fail the style check, instead of walking them through editor-specific setup, we can just ask that they run `yarn style:fix` and amend their PR.
* Integrates style checks into CI; runs concurrently with linter

The PR is broken into two commits:

* 6668153157fbd4afcf667231c2c0c430f07d87ba -- Enable / integrate prettier
* 3297c74678804c7be045f4d3c38d983a418189bf -- Remediate all outstanding issues; this was accomplished by running `yarn style:fix` and contains no manual edits.

