### PR TITLE
allow API address to be overridden with env var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,8 +114,8 @@ IMAGE_PULL_POLICY ?= Always
 
 .PHONY: hack-deploy
 hack-deploy:
-ifndef BRIGADE_API_ADDRESS
-	@echo "BRIGADE_API_ADDRESS must be defined" && false
+ifndef REACT_APP_BRIGADE_API_ADDRESS
+	@echo "REACT_APP_BRIGADE_API_ADDRESS must be defined" && false
 endif
 	helm dep up charts/brigade-dashboard && \
 	helm upgrade brigade-dashboard charts/brigade-dashboard \
@@ -126,7 +126,7 @@ endif
 		--set image.repository=$(DOCKER_IMAGE_NAME) \
 		--set image.tag=$(IMMUTABLE_DOCKER_TAG) \
 		--set image.pullPolicy=$(IMAGE_PULL_POLICY) \
-		--set brigade.apiAddress=$(BRIGADE_API_ADDRESS)
+		--set brigade.apiAddress=$(REACT_APP_BRIGADE_API_ADDRESS)
 
 .PHONY: hack
 hack: hack-push hack-deploy

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -1,1 +1,2 @@
-export const apiAddress = window.location.origin + "/api"
+export const apiAddress =
+  process.env.REACT_APP_BRIGADE_API_ADDRESS || window.location.origin + "/api"


### PR DESCRIPTION
This is a long overdue fix that makes the address of the API server configurable without touching `Config.js`.

The app only uses `REACT_APP_BRIGADE_API_ADDRESS` when the development server is running.

 `REACT_APP_BRIGADE_API_ADDRESS` is not defined at _build time_ (e.g. in the `Dockerfile`), so the address of the API server falls back to `window.location.origin + "/api"` (i.e. a reverse proxy for the API server, whose address is install-time configurable).

See https://create-react-app.dev/docs/adding-custom-environment-variables/ for better understanding of how this works.