### PR TITLE
build arm64 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.13.2-alpine3.15 as builder
+FROM --platform=$BUILDPLATFORM node:16.13.2-alpine3.15 as builder
 
 WORKDIR /app
 
@@ -13,7 +13,7 @@ COPY . .
 # Build the react app in production mode. Artifacts will be stored in build/
 RUN yarn build
 
-FROM nginxinc/nginx-unprivileged:1.20.2-alpine
+FROM nginxinc/nginx-unprivileged:1.20.2-alpine as final
 
 USER root
 

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ build:
 	docker buildx build \
 		-t $(DOCKER_IMAGE_NAME):$(IMMUTABLE_DOCKER_TAG) \
 		-t $(DOCKER_IMAGE_NAME):$(MUTABLE_DOCKER_TAG) \
-		--platform linux/amd64 \
+		--platform linux/amd64,linux/arm64/v8 \
 		.
 
 ################################################################################
@@ -100,7 +100,7 @@ push:
 	docker buildx build \
 		-t $(DOCKER_IMAGE_NAME):$(IMMUTABLE_DOCKER_TAG) \
 		-t $(DOCKER_IMAGE_NAME):$(MUTABLE_DOCKER_TAG) \
-		--platform linux/amd64 \
+		--platform linux/amd64,linux/arm64/v8 \
 		--push \
 		.
 


### PR DESCRIPTION
Fixes #67.

#67 notes we were building for arm64 prior to #3, but it was taking too long and often timing out.

This PR employs a slightly different approach. The build happens entirely in an amd64 container and the final product is copied to an arm64 container.