### PR TITLE
ux: disable logs tabs for unauthorized users

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -56,6 +56,9 @@ a:not(.nav-link) {
       cursor: pointer;
     }
   }
+  .disabled {
+    color: $text !important;
+  }
 }
 
 .nav-pills .nav-link.active {

--- a/src/Event.tsx
+++ b/src/Event.tsx
@@ -51,20 +51,12 @@ class Event extends React.Component<EventProps, EventState> {
     })
 
     if(projectId) {
-      const authzList = await coreClient.projects().authz().roleAssignments().list(projectId)
-      const userId = await getUserID()
-      let logAccessEnabled = false
+      const principalData = await getClient().authn().whoAmI()
+      const selector = {role: "PROJECT_USER", principal: principalData}
+      const authzList = await coreClient.projects().authz().roleAssignments().list(projectId, selector)
 
-      for(const authzItem of authzList.items) {
-        if(authzItem.role === "PROJECT_USER" && authzItem?.principal.id === userId) {
-          this.setState({userHasLogAccess: true})
-          logAccessEnabled = true
-          break
-        }
-      }
-
-      if(!logAccessEnabled) {
-        this.setState({userHasLogAccess: false})
+      if(authzList.items) {
+        this.setState({userHasLogAccess: true})
       }
     }
   }


### PR DESCRIPTION
When viewing events/jobs, should gray out log tabs if the user doesn't have access.

Fixes #65.